### PR TITLE
Fixed test_add_reference_page_returns_redirect_before_logging_in in test_views.py

### DIFF
--- a/app/front/views.py
+++ b/app/front/views.py
@@ -17,7 +17,7 @@ from refs.models import Ref, get_ref_from_doi
 from .utils import canonicalize_doi
 from refs.forms import RefForm
 from refs.filters import RefFilter
-
+from django.contrib.auth.decorators import login_required
 
 def index(request):
     return render(request, 'front/index.html')
@@ -68,7 +68,7 @@ def search(request):
               'paginator': paginator})
     return render(request, 'front/search.html', c)
 
-
+@login_required
 def refs_add(request, pk=None):
     c = {'pk': pk if pk else ''}
     if request.method == 'POST':

--- a/app/tests/test_views.py
+++ b/app/tests/test_views.py
@@ -17,9 +17,7 @@ class StatuscodeTest(TestCase):
 
     def test_add_reference_page_returns_redirect_before_logging_in(self):
         response = self.client.get('/add-references/')
-        # FIXME: Status code is now 404 instead of 302. Couldn't think
-        # of why, quickly.
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 302)
 
     def test_add_reference_page_returns_ok_after_logging_in(self):
         self.client.force_login(self.test_user)
@@ -43,3 +41,4 @@ class TemplateTest(TestCase):
         self.client.force_login(self.test_user)
         response = self.client.get('/add-references/')
         self.assertTemplateUsed(response, 'front/add_reference.html')
+


### PR DESCRIPTION
Had to add @login_required decorator to the relevant views.py method to get the 302 redirect working.